### PR TITLE
Add printable version of profile

### DIFF
--- a/src/assets/icons/print.svg
+++ b/src/assets/icons/print.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>

--- a/src/components/app/root/AppRoot.tsx
+++ b/src/components/app/root/AppRoot.tsx
@@ -30,6 +30,49 @@ export class AppRoot {
     }
   }
 
+  openPrint() {
+    const profile = appState.profile;
+    const dogs = appState.dogs;
+
+    const dogsHtml = dogs.map((dog) => `
+      <li>
+        <strong>${dog.name}</strong> - ${dog.age}y, ${dog.breed}, ${dog.sex === 'm' ? 'Male' : 'Female'}, ${dog.division}, ${dog.indication}, ${dog.castrated ? 'Castrated' : 'Not castrated'}
+      </li>
+    `).join('');
+
+    const html = `<!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8" />
+      <title>Print</title>
+      <style>
+        body { font-family: Arial, sans-serif; padding: 1rem; }
+        h1 { font-size: 1.2rem; margin: 0; }
+        h2 { font-size: 1rem; margin-top: 1rem; }
+        ul { list-style: none; padding: 0; }
+        li { margin-bottom: 0.2rem; }
+        @media print { @page { size: A6; margin: 10mm; } }
+      </style>
+    </head>
+    <body>
+      <h1>${profile?.name || ''}</h1>
+      <p>Phone: ${profile?.phone || ''}</p>
+      <p>Organisation: ${profile?.organisation || ''}</p>
+      <p>Unit: ${profile?.unitName || ''}</p>
+      <p>${profile?.notes || ''}</p>
+      <h2>Dogs</h2>
+      <ul>${dogsHtml}</ul>
+      <script>window.onload = function() { window.print(); }</script>
+    </body>
+    </html>`;
+
+    const win = window.open('', '_blank');
+    if (win) {
+      win.document.write(html);
+      win.document.close();
+    }
+  }
+
   render() {
     return (
       <div class="app-wrapper">
@@ -52,6 +95,11 @@ export class AppRoot {
               this.openQRCode();
             }}>
               <img src="/assets/icons/qr-code.svg" alt="QR Code" class="app-qr-code-icon" />
+            </li>
+            <li onClick={() => {
+              this.openPrint();
+            }}>
+              <img src="/assets/icons/print.svg" alt="Print" class="icon" />
             </li>
           </ul>
         </header>


### PR DESCRIPTION
## Summary
- add `openPrint` method to render text-only profile and dog list in new window
- add Print icon asset
- expose Print button in the navigation

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ff5eee7c88331ac42500916992d9e