### PR TITLE
Fix avalanche division label

### DIFF
--- a/src/components/app/dog/AppDog.tsx
+++ b/src/components/app/dog/AppDog.tsx
@@ -115,7 +115,7 @@ export class AppDog {
             <option selected={this.dog.division === 'mantrailing'} value="mantrailing">Mantrailing</option>
             <option selected={this.dog.division === 'area'} value="area">Area search</option>
             <option selected={this.dog.division === 'rubble'} value="rubble">Rubble search</option>
-            <option selected={this.dog.division === 'avalanche'} value="avalanche">Avalance search</option>
+            <option selected={this.dog.division === 'avalanche'} value="avalanche">Avalanche search</option>
             <option selected={this.dog.division === 'water'} value="water">Water search</option>
           </select> }
           { appState.mode === 'view' && <p>


### PR DESCRIPTION
## Summary
- correct the label for avalanche division

## Testing
- `npm run build` *(fails: stencil not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff74fb6a88331b56597078e19fb31