### PR TITLE
Fix comment about disabling service worker

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,7 +9,7 @@ export const config: Config = {
   outputTargets: [
     {
       type: 'www',
-      // comment the following line to disable service workers in production
+      // set `serviceWorker` to `null` to disable service workers in production
       serviceWorker: null,
       baseUrl: 'https://myapp.local/',
     },


### PR DESCRIPTION
## Summary
- fix the comment explaining how to disable service workers

## Testing
- `npm run build` *(fails: stencil not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff765deec8331bdef686860c1f7eb