### PR TITLE
Add AppProfile spec

### DIFF
--- a/src/components/app/profile/AppProfile.spec.tsx
+++ b/src/components/app/profile/AppProfile.spec.tsx
@@ -1,0 +1,30 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { AppProfile } from './AppProfile';
+import { appState } from '../../../store/AppState';
+
+describe('app-profile', () => {
+  it('renders selected organisation', async () => {
+    appState.mode = 'edit';
+    appState.profile = {
+      name: '',
+      phone: '',
+      organisation: 'drk',
+      unitName: '',
+      notes: '',
+    };
+
+    const page = await newSpecPage({
+      components: [AppProfile],
+      html: `<app-profile></app-profile>`,
+    });
+
+    await page.waitForChanges();
+    const select = page.root.querySelector('select');
+    expect(select).not.toBeNull();
+    expect(select.value).toBe('drk');
+
+    const option = select.querySelector('option[value="drk"]');
+    expect(option).not.toBeNull();
+    expect(option.selected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add an AppProfile test that checks organisation selection

## Testing
- `npx stencil test --spec` *(fails: Expected "drk" Received: undefined)*

------
https://chatgpt.com/codex/tasks/task_e_683ff76acfdc83318a0ac1a1a7ac094a