### PR TITLE
Fix selected state for 'Other' organisation option

### DIFF
--- a/src/components/app/profile/AppProfile.tsx
+++ b/src/components/app/profile/AppProfile.tsx
@@ -60,7 +60,7 @@ export class AppProfile {
             {this.organisations.map(org => (
               <option selected={appState.profile.organisation === org.name} value={org.id} key={org.id}>{org.name}</option>
             ))}
-            <option value="other">Other</option>
+            <option value="other" selected={appState.profile.organisation === 'other'}>Other</option>
           </select> }
           { appState.mode === 'view' && <p>{ this.organisations.find((organisation) => {
             return organisation.id === appState.profile.organisation;


### PR DESCRIPTION
## Summary
- ensure the `Other` option in profile organisation dropdown keeps selection state

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68402717e1d88331b6b30fda1c483fdc