### PR TITLE
Show Add Dog button when no dogs present

### DIFF
--- a/src/components/app/root/AppRoot.tsx
+++ b/src/components/app/root/AppRoot.tsx
@@ -112,7 +112,7 @@ export class AppRoot {
             <div class="app-dogs-wrapper">
               <div class="app-dogs-header">
                 <h2>Dogs</h2>
-                { appState.mode === 'edit' && <button
+                { (appState.mode === 'edit' || appState.dogs.length === 0) && <button
                   class="app-add-dog-button"
                   onClick={() => {
                     const newDog:IDog = {


### PR DESCRIPTION
## Summary
- show `Add Dog` button when there are no dogs, even outside of edit mode

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684162b704bc833182fc559fa32c63dd