### PR TITLE
Fix dog name and disable options if profile incomplete

### DIFF
--- a/src/assets/translations.json
+++ b/src/assets/translations.json
@@ -40,6 +40,7 @@
     "phone_placeholder": "Phone",
     "unit_name_placeholder": "Unit name",
     "notes_placeholder": "Notes",
+    "unnamed": "Unnamed",
     "close": "Close"
   },
   "de": {
@@ -83,6 +84,7 @@
     "phone_placeholder": "Telefon",
     "unit_name_placeholder": "Einheitsname",
     "notes_placeholder": "Notizen",
+    "unnamed": "Unbenannt",
     "close": "Schließen"
   },
   "fr": {
@@ -126,6 +128,7 @@
     "phone_placeholder": "Téléphone",
     "unit_name_placeholder": "Nom de l'unité",
     "notes_placeholder": "Notes",
+    "unnamed": "Sans nom",
     "close": "Fermer"
   }
 }

--- a/src/components/app/dog/AppDog.tsx
+++ b/src/components/app/dog/AppDog.tsx
@@ -53,7 +53,7 @@ export class AppDog {
       <div class="dog-wrapper dog-wrapper-view">
         <div class="form-group dog-name">
           <label htmlFor="name">{ t('name', 'Name') }</label>
-          <p>{ this.dog.name }</p>
+          <p>{ this.dog.name || t('unnamed', 'Unnamed') }</p>
         </div>
         <div class="form-group dog-age">
           <label htmlFor="age">{ t('age', 'Age') }</label>

--- a/src/components/app/root/AppRoot.css
+++ b/src/components/app/root/AppRoot.css
@@ -57,6 +57,12 @@
       justify-content: center;
       align-items: center;
 
+      &.disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        pointer-events: none;
+      }
+
       img {
         width: 1.2rem;
         height: 1.2rem;

--- a/src/components/app/root/AppRoot.tsx
+++ b/src/components/app/root/AppRoot.tsx
@@ -39,7 +39,7 @@ export class AppRoot {
       const divs = dog.divisions.map(d => `${d.division} (${d.indication})`).join(', ');
       return `
       <li>
-        <strong>${dog.name}</strong> - ${dog.age}y, ${dog.breed}, ${dog.sex === 'm' ? 'Male' : 'Female'}, ${divs}, ${dog.castrated ? 'Castrated' : 'Not castrated'}
+        <strong>${dog.name || 'Unnamed'}</strong> - ${dog.age}y, ${dog.breed}, ${dog.sex === 'm' ? 'Male' : 'Female'}, ${divs}, ${dog.castrated ? 'Castrated' : 'Not castrated'}
       </li>`;
     }).join('');
 
@@ -77,6 +77,7 @@ export class AppRoot {
   }
 
   render() {
+    const profileComplete = !!(appState.profile?.name && appState.profile?.phone);
     return (
       <div class="app-wrapper">
         <div class="app-inner-wrapper">
@@ -95,14 +96,18 @@ export class AppRoot {
               { ['edit', 'code'].includes(appState.mode) && <li onClick={() => { appState.mode = 'view'; }}>
                 <img src="/assets/icons/eye.svg" alt="View" class="icon" />
               </li> }
-              <li onClick={() => {
-                this.openQRCode();
-              }}>
+              <li
+                class={{ disabled: !profileComplete }}
+                onClick={() => {
+                  if (profileComplete) this.openQRCode();
+                }}>
                 <img src="/assets/icons/qr-code.svg" alt="QR Code" class="app-qr-code-icon" />
               </li>
-              <li onClick={() => {
-                this.openPrint();
-              }}>
+              <li
+                class={{ disabled: !profileComplete }}
+                onClick={() => {
+                  if (profileComplete) this.openPrint();
+                }}>
                 <img src="/assets/icons/printer.svg" alt="Print" class="icon" />
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- display `Unnamed` when a dog has no name
- disable QR code and Print buttons until profile contains name and phone
- style disabled state in header menu
- add translations for the new text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68430a4e846883319a4cefaecf3bc0f5