### PR TITLE
Fix print action to reliably trigger browser printing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,7 +149,17 @@ const AppShell = () => {
     printWindow.document.open();
     printWindow.document.write(markup);
     printWindow.document.close();
-    printWindow.focus();
+
+    const triggerPrint = () => {
+      printWindow.focus();
+      printWindow.print();
+    };
+
+    if (printWindow.document.readyState === "complete") {
+      triggerPrint();
+    } else {
+      printWindow.addEventListener("load", triggerPrint, { once: true });
+    }
   };
 
   const handleScanPayload = (payload: string) => {

--- a/src/lib/print.ts
+++ b/src/lib/print.ts
@@ -100,20 +100,6 @@ export const buildPrintMarkup = (
         <h2>${translations.dogs.title}</h2>
         <ul class="dogs">${dogItems || `<li>${translations.dogs.empty}</li>`}</ul>
       </section>
-      <script>
-        (function () {
-          const trigger = () => {
-            window.focus();
-            window.print();
-          };
-
-          if (document.readyState === "complete") {
-            trigger();
-          } else {
-            window.addEventListener("load", trigger, { once: true });
-          }
-        })();
-      </script>
     </body>
   </html>`;
 };


### PR DESCRIPTION
## Summary
- trigger printing from the parent window after the print document finishes loading
- simplify the generated print markup by removing the inline print script

## Testing
- `npm run lint` *(fails: missing @zxing/browser and @zxing/library types already absent in workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c89fa8b008331ad34ad05b19ad4e3)